### PR TITLE
fix: Fix crash on android when there is an invalid src

### DIFF
--- a/src/HTMLRenderers.js
+++ b/src/HTMLRenderers.js
@@ -29,7 +29,11 @@ function getImgProps(passProps) {
 }
 
 function normalizeUri(uri) {
-  return uri.startsWith("//") ? `https:${uri}` : uri;
+  const newUri = uri.replace(/[\"<>^`{|}]/g, "");
+  if (newUri.startsWith("//")) {
+    return `https:${newUri}`;
+  }
+  return newUri;
 }
 
 export function a(htmlAttribs, children, convertedCSSStyles, passProps) {


### PR DESCRIPTION
<!--
  MAKE SURE TO READ AND FOLLOW THIS TEMPLATE CLOSELY OR YOUR PR WILL BE
  REJECTED WITHOUT NOTICE
-->

### Checks

- [x] I have read the contribution guidelines regarding Pull Requests here: https://git.io/JJ0Pg 

### Description

<!--
  If you have any question regarding your contribution, ping us in our Discord
  #contributing channel: https://discord.gg/MwrZmBb
-->
Fix crash on android when `img` has illegal `src`, such as below:

> 01-10 11:20:33.271 32554 32616 E AndroidRuntime: java.lang.RuntimeException: java.net.URISyntaxException: Illegal character in authority at index 7: `http://<a>/`
01-10 11:20:33.271 32554 32616 E AndroidRuntime:        at okhttp3.HttpUrl.uri(HttpUrl.java:386)
01-10 11:20:33.271 32554 32616 E AndroidRuntime:        at okhttp3.internal.connection.RouteSelector.resetNextProxy(RouteSelector.java:129)
01-10 11:20:33.271 32554 32616 E AndroidRuntime:        at okhttp3.internal.connection.RouteSelector.<init>(RouteSelector.java:63)
01-10 11:20:33.271 32554 32616 E AndroidRuntime:        at okhttp3.internal.connection.StreamAllocation.<init>(StreamAllocation.java:101)
01-10 11:20:33.271 32554 32616 E AndroidRuntime:        at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:112)
01-10 11:20:33.271 32554 32616 E AndroidRuntime:        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
01-10 11:20:33.271 32554 32616 E AndroidRuntime:        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
01-10 11:20:33.271 32554 32616 E AndroidRuntime:        at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:254)
01-10 11:20:33.271 32554 32616 E AndroidRuntime:        at okhttp3.RealCall$AsyncCall.execute(RealCall.java:200)
01-10 11:20:33.271 32554 32616 E AndroidRuntime:        at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
01-10 11:20:33.271 32554 32616 E AndroidRuntime:        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
01-10 11:20:33.271 32554 32616 E AndroidRuntime:        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
01-10 11:20:33.271 32554 32616 E AndroidRuntime:        at java.lang.Thread.run(Thread.java:764)


related: https://github.com/square/okhttp/pull/5674