### PR TITLE
fix: wrong prop name in documentation

### DIFF
--- a/apps/website/docs/migration-guide.mdx
+++ b/apps/website/docs/migration-guide.mdx
@@ -53,10 +53,10 @@ renderers](#migrate-custom-renderers).
 
 | Prop                 | Remarks                                                                                                                                                        |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `containerStyle`       | You can use `baseStyles` instead.                                                                                                                              |
+| `containerStyle`       | You can use `baseStyle` instead.                                                                                                                              |
 | `customWrapper`        |                                                                                                                                                                |
 | `ptSize`               |                                                                                                                                                                |
-| `baseFontStyle`        | You can use `baseStyles` instead.                                                                                                                              |
+| `baseFontStyle`        | You can use `baseStyle` instead.                                                                                                                              |
 | `alterData`            | You can use `domVisitors.onText` instead. See [Dom Tampering](./guides/dom-tampering.mdx#example-altering-data).                                               |
 | `alterChildren`        | You can use `domVisitors.onElement` instead. See [Dom Tampering](./guides/dom-tampering.mdx#example-inserting-elements).                                       |
 | `alterNode`            | You can use `domVisitors.onElement` instead. See [Dom Tampering](./guides/dom-tampering.mdx#example-removing-elements).                                        |


### PR DESCRIPTION


<!--
  MAKE SURE TO READ AND FOLLOW THIS TEMPLATE CLOSELY OR YOUR PR WILL BE
  REJECTED WITHOUT NOTICE
-->

### Checks

- [X] I have read the contribution guidelines regarding Pull Requests here: https://git.io/JJ0Pg 

### Description

RenderHTMLProps interface does not have a `baseStyles` prop it should be `baseStyle` instead

<!--
  If you have any question regarding your contribution, ping us in our Discord
  #contributing channel: https://discord.gg/MwrZmBb
-->