### PR TITLE
fix: can't find variable performance

### DIFF
--- a/packages/render-html/src/hooks/useProfiler.ts
+++ b/packages/render-html/src/hooks/useProfiler.ts
@@ -3,7 +3,7 @@ import identity from 'ramda/src/identity';
 
 declare const performance: { now: () => number };
 
-const useProfiler = __DEV__
+const useProfiler = __DEV__ && window['performance']
   ? function useProfiler({ name, prop }: { name?: string; prop?: string }) {
       const lastUpdate = useRef(0);
       const profile = useCallback(


### PR DESCRIPTION
<!--
  MAKE SURE TO READ AND FOLLOW THIS TEMPLATE CLOSELY OR YOUR PR WILL BE
  REJECTED WITHOUT NOTICE
-->

### Checks

- [x ] I have read the contribution guidelines regarding Pull Requests here: https://git.io/JJ0Pg 

### Description

In iPhone 8, window.performance is not defined, therefore it gives the error `can't find variable performance`. I put a small check to make sure we are not calling `performance.now()` when it is not defined.

<!--
  If you have any question regarding your contribution, ping us in our Discord
  #contributing channel: https://discord.gg/MwrZmBb
-->