### PR TITLE
Fix react keys warning when using dangerouslyDisableWhitespaceCollapsing

### DIFF
--- a/packages/render-html/src/renderChildren.tsx
+++ b/packages/render-html/src/renderChildren.tsx
@@ -18,7 +18,7 @@ const mapCollapsibleChildren = (
     ? null
     : collapseTopMarginForChild(n, tchildren);
   const propsFromParent = { ...propsForChildren, collapsedMarginTop };
-  const key = childTnode.nodeIndex;
+  const key = `${childTnode.nodeIndex}_${n}`;
   const childElement = React.createElement(TNodeRenderer, {
     propsFromParent,
     tnode: childTnode,


### PR DESCRIPTION


<!--
  MAKE SURE TO READ AND FOLLOW THIS TEMPLATE CLOSELY OR YOUR PR WILL BE
  REJECTED WITHOUT NOTICE
-->

### Checks

- [x] I have read the contribution guidelines regarding Pull Requests here: https://git.io/JJ0Pg 

### Description

<!--
  If you have any question regarding your contribution, ping us in our Discord
  #contributing channel: https://discord.gg/MwrZmBb
-->
Fixed issue: https://github.com/meliorence/react-native-render-html/issues/562

I've read section about regression tests in [Contributor's Guide](https://github.com/meliorence/react-native-render-html/blob/master/CONTRIBUTING.adoc#bug-fixes), but not sure how to implement the test, since we essentially need to check for the absence of the yellow box warning.