### PR TITLE
Move config for img and a into named interface

### DIFF
--- a/packages/render-html/src/shared-types.ts
+++ b/packages/render-html/src/shared-types.ts
@@ -164,7 +164,7 @@ export interface ImgElementConfig {
    * memoize it.
    */
   initialDimensions?: ImageDimensions;
-};
+}
 
 /**
  * Configuration for a.

--- a/packages/render-html/src/shared-types.ts
+++ b/packages/render-html/src/shared-types.ts
@@ -146,6 +146,52 @@ export interface ListElementConfig {
 }
 
 /**
+ * Configuration for img.
+ *
+ * @public
+ */
+export interface ImgElementConfig {
+  /**
+   * Support for relative percent-widths.
+   *
+   * @defaultValue false
+   */
+  enableExperimentalPercentWidth?: boolean;
+  /**
+   * Default width and height to display while image's dimensions are being retrieved.
+   *
+   * @remarks Changes to this prop will cause a react tree update. Always
+   * memoize it.
+   */
+  initialDimensions?: ImageDimensions;
+};
+
+/**
+ * Configuration for a.
+ *
+ * @public
+ */
+export interface AElementConfig {
+  /**
+   * A callback to handle anchors presses.
+   *
+   * @remarks The `href` argument has been normalized, see {@link useNormalizedUrl}.
+   *
+   * @defaultValue A function using React Native `Linking.onpenUrl`.
+   * @param event - The {@link GestureResponderEvent} event.
+   * @param href - The normalized href, see {@link useNormalizedUrl}.
+   * @param htmlAttribs - The attributes of the underlying {@link Element}.
+   * @param target - The normalized `target` for this hyperlink.
+   */
+  onPress?: (
+    event: GestureResponderEvent,
+    href: string,
+    htmlAttribs: Record<string, string>,
+    target: '_blank' | '_self' | '_parent' | '_top'
+  ) => void;
+}
+
+/**
  * Props for custom renderers. The convention is to declare a field per tag name.
  * In doing so, you can benefit from `useRendererProps('tagname')` in custom renderers.
  *
@@ -163,40 +209,8 @@ export interface ListElementConfig {
  * @public
  */
 export interface RenderersProps extends Record<string, any> {
-  a: {
-    /**
-     * A callback to handle anchors presses.
-     *
-     * @remarks The `href` argument has been normalized, see {@link useNormalizedUrl}.
-     *
-     * @defaultValue A function using React Native `Linking.onpenUrl`.
-     * @param event - The {@link GestureResponderEvent} event.
-     * @param href - The normalized href, see {@link useNormalizedUrl}.
-     * @param htmlAttribs - The attributes of the underlying {@link Element}.
-     * @param target - The normalized `target` for this hyperlink.
-     */
-    onPress?: (
-      event: GestureResponderEvent,
-      href: string,
-      htmlAttribs: Record<string, string>,
-      target: '_blank' | '_self' | '_parent' | '_top'
-    ) => void;
-  };
-  img: {
-    /**
-     * Support for relative percent-widths.
-     *
-     * @defaultValue false
-     */
-    enableExperimentalPercentWidth?: boolean;
-    /**
-     * Default width and height to display while image's dimensions are being retrieved.
-     *
-     * @remarks Changes to this prop will cause a react tree update. Always
-     * memoize it.
-     */
-    initialDimensions?: ImageDimensions;
-  };
+  a: AElementConfig;
+  img: ImgElementConfig;
   ol: ListElementConfig;
   ul: ListElementConfig;
 }


### PR DESCRIPTION
### Checks

- [x] I have read the contribution guidelines regarding Pull Requests here: https://git.io/JJ0Pg 

### Description
We are using this library to render HTML in several places in the DataCamp app. We have a custom renderer for `<img>` tags, which we need to pass some extra config (props) to. I tried using TypeScript module augmentation to add those props to the `RenderersProps['img']` type, [as the docs suggest](https://github.com/meliorence/react-native-render-html/blob/master/packages/render-html/src/shared-types.ts#L152):

```ts
declare module 'react-native-render-html' {
  export interface RenderersProps {
    img?: {
      fullImageTappable: boolean
    }
  }
}
export {}
```

Unfortunately, this didn't work: the new field was not picked up by TS. Apparently, you can _add_ new properties on the `RenderersProps` type this way (i.e. for new element types), but you can't _update_ the built-in ones, as they are anonymous object types. For example, the following _does_ work as expected:

```ts
declare module 'react-native-render-html' {
  export interface RenderersProps {
    div?: {
      someProp: boolean
    }
  }
}
export {}
```

However, this is not what we needed: we want to add a prop for an _existing_ element. By moving those types to named interfaces, it's now possible to extend them:

```ts
declare module 'react-native-render-html' {
  export interface ImgElementConfig {
    fullImageTappable?: boolean
  }
}
export {}
```