### PR TITLE
Improvement/image border radius support

### DIFF
--- a/packages/render-html/src/elements/__tests__/IMGElement.test.tsx
+++ b/packages/render-html/src/elements/__tests__/IMGElement.test.tsx
@@ -474,5 +474,25 @@ describe('IMGElement', () => {
         height: 100
       });
     });
+    it('should retain border-related style', async () => {
+      const source = { uri: 'http://via.placeholder.com/640x360' };
+      const style = {
+        borderBottomLeftRadius: 10,
+        borderBottomRightRadius: 10,
+        borderTopLeftRadius: 10,
+        borderTopRightRadius: 10
+      };
+      const { findByTestId } = render(
+        <HTMLImgElement source={source} style={style} />
+      );
+      const image = await findByTestId('image-success');
+      expect(image).toBeTruthy();
+      expect(image).toHaveStyle({
+        borderBottomLeftRadius: 10,
+        borderBottomRightRadius: 10,
+        borderTopLeftRadius: 10,
+        borderTopRightRadius: 10
+      });
+    });
   });
 });

--- a/packages/render-html/src/elements/extractImageStyleProps.ts
+++ b/packages/render-html/src/elements/extractImageStyleProps.ts
@@ -6,7 +6,11 @@ import pick from 'ramda/src/pick';
 const extractProps = pick<keyof ImageStyle>([
   'resizeMode',
   'tintColor',
-  'overlayColor'
+  'overlayColor',
+  'borderBottomLeftRadius',
+  'borderBottomRightRadius',
+  'borderTopLeftRadius',
+  'borderTopRightRadius'
 ]);
 
 function mapObjectFit(objectFit: WebBlockStyles['objectFit']) {


### PR DESCRIPTION
### Checks

- [x] I have read the contribution guidelines regarding Pull Requests here: https://git.io/JJ0Pg 

### Description

Add support for `borderRadius` for `Image` components.

It seems that the processor resolves `borderRadius` to the individual fields of:
* borderBottomLeftRadius
* borderBottomRightRadius
* borderTopLeftRadius
* borderTopRightRadius

The `border*Radius` properties need to be applied to the actual `Image` component and not on the container. You can find a snack example of that [here](https://snack.expo.dev/UKvfUS_Ms).

Fixes meliorence/react-native-render-html/issues/582.